### PR TITLE
nix: enable static linking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,10 +12,14 @@
       pkgs = import nixpkgs {
         inherit system;
         overlays = [ (import ./nix/overlay.nix) ];
+        config.allowUnsupportedSystem = true;
       };
     in
     {
-      packages.default = pkgs.ml-tdse;
+      packages = {
+        default = pkgs.ml-tdse;
+        static = pkgs.pkgsStatic.ml-tdse;
+      };
 
       devShell = with pkgs; mkShell {
         buildInputs = [ fortran-language-server ] ++

--- a/nix/pkgs/ml-tdse/default.nix
+++ b/nix/pkgs/ml-tdse/default.nix
@@ -4,8 +4,7 @@
 , meson
 , ninja
 , pkg-config
-, blas
-, lapack
+, openblas
 , fftw
 }:
 
@@ -26,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    blas
-    lapack
+    openblas
     (lib.getLib fftw)
     (lib.getDev fftw)
   ];


### PR DESCRIPTION
`nix build .#static` gives a fully statically linked executable at `result/bin/ML-TDSE` as an alternative to a bundled executable.